### PR TITLE
fix equal and hashcode methods for entities and dtos

### DIFF
--- a/src/main/java/de/witcom/itsm/serviceaccess/dto/ServiceAccessBaseDTO.java
+++ b/src/main/java/de/witcom/itsm/serviceaccess/dto/ServiceAccessBaseDTO.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import de.witcom.itsm.serviceaccess.entity.ServiceAccessOtherOperatorGroup;
 import de.witcom.itsm.serviceaccess.entity.Tag;
 import de.witcom.itsm.serviceaccess.enums.ServiceAccessOfferScope;
 import de.witcom.itsm.serviceaccess.enums.ServiceAccessScope;
@@ -48,5 +49,22 @@ public class ServiceAccessBaseDTO {
 		
 		
 	}
+	
+    @Override
+    public int hashCode() {
+        return 13;
+    }
+ 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ServiceAccessBaseDTO other = (ServiceAccessBaseDTO) obj;
+        return this.getId() != null && this.getId().equals(other.getId());
+    }
 
 }

--- a/src/main/java/de/witcom/itsm/serviceaccess/dto/ServiceAccessInfraOtherOperatorDTO.java
+++ b/src/main/java/de/witcom/itsm/serviceaccess/dto/ServiceAccessInfraOtherOperatorDTO.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Data
-@EqualsAndHashCode(callSuper=false)
+//@EqualsAndHashCode(callSuper=false)
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString(callSuper=true, includeFieldNames=true)
@@ -16,6 +16,25 @@ public class ServiceAccessInfraOtherOperatorDTO extends ServiceAccessBaseDTO{
 	
 	private boolean usedInGroup;
 	private String constraints;
+	
+	
+    @Override
+    public int hashCode() {
+        return 15;
+    }
+ 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ServiceAccessInfraOtherOperatorDTO other = (ServiceAccessInfraOtherOperatorDTO) obj;
+        return this.getId() != null && this.getId().equals(other.getId());
+    }
+
 
 
 }

--- a/src/main/java/de/witcom/itsm/serviceaccess/dto/ServiceAccessInfraPassiveDTO.java
+++ b/src/main/java/de/witcom/itsm/serviceaccess/dto/ServiceAccessInfraPassiveDTO.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Data
-@EqualsAndHashCode(callSuper=false)
+//@EqualsAndHashCode(callSuper=false)
 @ToString(callSuper=true, includeFieldNames=true)
 public class ServiceAccessInfraPassiveDTO extends ServiceAccessBaseDTO{
 
@@ -16,5 +16,23 @@ public class ServiceAccessInfraPassiveDTO extends ServiceAccessBaseDTO{
 		
 		
 	}
+	
+    @Override
+    public int hashCode() {
+        return 14;
+    }
+ 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ServiceAccessInfraPassiveDTO other = (ServiceAccessInfraPassiveDTO) obj;
+        return this.getId() != null && this.getId().equals(other.getId());
+    }
+
 	
 }

--- a/src/main/java/de/witcom/itsm/serviceaccess/dto/ServiceAccessOtherOperatorGroupDTO.java
+++ b/src/main/java/de/witcom/itsm/serviceaccess/dto/ServiceAccessOtherOperatorGroupDTO.java
@@ -15,5 +15,23 @@ import lombok.ToString;
 public class ServiceAccessOtherOperatorGroupDTO extends ServiceAccessBaseDTO{
 
 	Set<ServiceAccessInfraOtherOperatorDTO> otherOperators;
+	
+    @Override
+    public int hashCode() {
+        return 16;
+    }
+ 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ServiceAccessOtherOperatorGroupDTO other = (ServiceAccessOtherOperatorGroupDTO) obj;
+        return this.getId() != null && this.getId().equals(other.getId());
+    }
+	
 
 }

--- a/src/main/java/de/witcom/itsm/serviceaccess/entity/ServiceAccessBase.java
+++ b/src/main/java/de/witcom/itsm/serviceaccess/entity/ServiceAccessBase.java
@@ -124,4 +124,21 @@ public class ServiceAccessBase {
 		}
     }
     
+    @Override
+    public int hashCode() {
+        return 13;
+    }
+ 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ServiceAccessBase other = (ServiceAccessBase) obj;
+        return id != null && id.equals(other.getId());
+    }
+    
 }

--- a/src/main/java/de/witcom/itsm/serviceaccess/entity/ServiceAccessInfraOtherOperator.java
+++ b/src/main/java/de/witcom/itsm/serviceaccess/entity/ServiceAccessInfraOtherOperator.java
@@ -62,6 +62,24 @@ public class ServiceAccessInfraOtherOperator extends ServiceAccessBase{
 			this.setUsedInGroup(false);
 		}
 	}
+	
+    @Override
+    public int hashCode() {
+        return 15;
+    }
+ 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ServiceAccessInfraOtherOperator other = (ServiceAccessInfraOtherOperator) obj;
+        return this.getId() != null && this.getId().equals(other.getId());
+    }	
+
 
 	
 }

--- a/src/main/java/de/witcom/itsm/serviceaccess/entity/ServiceAccessInfraPassive.java
+++ b/src/main/java/de/witcom/itsm/serviceaccess/entity/ServiceAccessInfraPassive.java
@@ -31,4 +31,22 @@ public class ServiceAccessInfraPassive extends ServiceAccessBase{
 		
 	}
 	
+    @Override
+    public int hashCode() {
+        return 14;
+    }
+ 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ServiceAccessInfraPassive other = (ServiceAccessInfraPassive) obj;
+        return this.getId() != null && this.getId().equals(other.getId());
+    }	
+	
+	
 }

--- a/src/main/java/de/witcom/itsm/serviceaccess/entity/ServiceAccessOtherOperatorGroup.java
+++ b/src/main/java/de/witcom/itsm/serviceaccess/entity/ServiceAccessOtherOperatorGroup.java
@@ -83,6 +83,23 @@ public class ServiceAccessOtherOperatorGroup extends ServiceAccessBase{
 		
 		
 	}
+	
+    @Override
+    public int hashCode() {
+        return 16;
+    }
+ 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ServiceAccessOtherOperatorGroup other = (ServiceAccessOtherOperatorGroup) obj;
+        return this.getId() != null && this.getId().equals(other.getId());
+    }		
 
 	
 }

--- a/src/test/java/de/witcom/itsm/serviceaccess/MapperTests.java
+++ b/src/test/java/de/witcom/itsm/serviceaccess/MapperTests.java
@@ -1,8 +1,10 @@
 package de.witcom.itsm.serviceaccess;
 
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -158,6 +160,49 @@ class MapperTests {
 				);
 		
 		return infraPassive1;
+	}
+	@Test
+	void testEquals() {
+
+		HashSet<ResourceReference> resRef = new HashSet<ResourceReference>();
+		ResourceReference res = new ResourceReference();
+		res.setType(ResourceType.RMDB_OBJECT);
+		res.setReferenceId("SOME-RMDB-ID");
+		res.setDescription("NOTUNIQUE");
+		resRef.add(res );
+		
+		res = new ResourceReference();
+		res.setType(ResourceType.RMDB_ZONE);
+		res.setReferenceId("NX-ID");
+		res.setDescription("NOTUNIQUE");
+		resRef.add(res );
+
+		res = new ResourceReference();
+		res.setType(ResourceType.CRM_CONTACT);
+		res.setReferenceId("NOTUNIQUE");
+		resRef.add(res);
+		
+		ServiceAccessInfraOtherOperator entity1 = ServiceAccessInfraOtherOperator.builder()
+				.id("SA000000001")
+				.projectId("20449")
+				.resources(resRef)
+				.build();
+		
+		ServiceAccessInfraOtherOperator entity2 = ServiceAccessInfraOtherOperator.builder()
+				.id("SA000000003")
+				.projectId("20449")
+				.resources(resRef)
+				.build();
+		
+		
+		//entities are not equal ?
+		assertThat(entity1,is(not(entity2)));
+		//dtos are not equal ?
+		assertThat(saMapper.toDto(entity1),is(not(saMapper.toDto(entity2))));
+		
+		
+		
+		
 	}
 
 	@Test


### PR DESCRIPTION
When mapping entity -> dto, some dtos where treated as equal, although they were'nt.
Probably caused by lombok. Added custom equals&hashcode methods that use primary-keys of the entities for comparison.
 